### PR TITLE
Fix sampling when no seed sequence given

### DIFF
--- a/theanolm/commands/sample.py
+++ b/theanolm/commands/sample.py
@@ -43,6 +43,7 @@ def add_arguments(parser):
         help='generate sentences of N tokens')
     argument_group.add_argument(
         '--seed-sequence', metavar='SEQUENCE', type=str,
+        default = "",
         help='Use SEQUENCE as seed; ie. first compute forward passes with the sequence, then generate')
 
     argument_group = parser.add_argument_group("configuration")


### PR DESCRIPTION
Simple mistake that I noticed I had added a while a back. When no seed sequence was given for sampling, seed sequence became `None`, which would lead to `AttributeError exception occurred: 'NoneType' object has no attribute 'strip'`